### PR TITLE
Configure worddelimiters as codepoints, not a utf-8 encoded string.

### DIFF
--- a/config.h
+++ b/config.h
@@ -20,7 +20,7 @@ float chscale = 1.0;
 
 // Characters that separate words.
 // This affects text selection.
-static char worddelimiters[] = " ";
+static Rune worddelimiters[] = {' '};
 
 // Timeouts for selection gestures, in milliseconds.
 unsigned int doubleclicktimeout = 300;


### PR DESCRIPTION
This simplifies selection snapping.